### PR TITLE
Better fee value and UTXO selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "discord.js": "14.15.3",
     "ecpair": "2.1.0",
     "fetch-plus-plus": "1.0.0",
+    "lodash": "4.17.21",
+    "p-do-whilst": "2.0.0",
     "tiny-secp256k1": "2.2.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,12 @@ importers:
       fetch-plus-plus:
         specifier: 1.0.0
         version: 1.0.0
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      p-do-whilst:
+        specifier: 2.0.0
+        version: 2.0.0
       tiny-secp256k1:
         specifier: 2.2.3
         version: 2.2.3
@@ -2090,6 +2096,13 @@ packages:
         integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
       }
     engines: { node: ">= 0.8.0" }
+
+  p-do-whilst@2.0.0:
+    resolution:
+      {
+        integrity: sha512-egyPJ7/c65DVu0S8UTN8EtmUsBb3L/3g5AcY3Af+ouFNkFMtwTVF2yQqZ4LjYPzz2mB5H1ytSlALR5jng/BSgg==,
+      }
+    engines: { node: ">=12" }
 
   p-limit@3.1.0:
     resolution:
@@ -4421,6 +4434,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  p-do-whilst@2.0.0: {}
 
   p-limit@3.1.0:
     dependencies:

--- a/src/bitcoin-client.js
+++ b/src/bitcoin-client.js
@@ -109,9 +109,8 @@ async function tryCreateAndBroadcastTx(keyPair, address, value, strategy) {
  * For that reason and only in that case (the node returns the error code -26),
  * the operation is retried with different selection strategies.
  *
- * Selecting the smaller value UTXOs first helps reducing the risk of creating
- * dust but the cost may be higher until all the those small transactions are
- * spent.
+ * Selecting the smaller value UTXOs first helps reduce the risk of creating
+ * dust but the cost may be higher until all those small transactions are spent.
  *
  * Selecting UTXOs at random reduces the risk of selecting the same UTXOs in
  * multiple concurrent operations, preventing the creation of long UTXO chains

--- a/src/bitcoin-client.js
+++ b/src/bitcoin-client.js
@@ -5,6 +5,7 @@ import * as secp256k1 from "tiny-secp256k1";
 import { mempoolJS } from "./mempool.js";
 
 const BASE_TX_SIZE = 10;
+const FEE_FACTOR = 1.25;
 const P2PKH_INPUT_SIZE = 148;
 const P2PKH_OUTPUT_SIZE = 34;
 const DUST_SATS = 546;
@@ -60,7 +61,8 @@ async function createAndBroadcastTx(keyPair, address, value, changeAddress) {
     bitcoin.addresses.getAddressTxsUtxo(fromAddress),
     bitcoin.fees.getFeesRecommended(),
   ]);
-  const { selected, change } = selectUtxos(utxos, value, fastestFee);
+  const feeLevel = Math.ceil(fastestFee * FEE_FACTOR);
+  const { selected, change } = selectUtxos(utxos, value, feeLevel);
   const psbt = new bitcoinJs.Psbt({ network: bitcoinJs.networks.testnet });
   psbt.addInputs(
     await Promise.all(


### PR DESCRIPTION
This PR makes two changes to the bot:

1) The fee is calculated based on the fastest fee rate and it is increased in 25% to increase the chances to confirm the transactions quickly, and

2) the transactions will be created as usual but if the node returns a "too-long-mempool-chain" error, the transaction is rebuilt (up to three times) but selecting UTXO at random.