### PR TITLE
Default fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bitcoin-faucet-bot",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "license": "MIT",
   "author": {
     "name": "Gabriel Montes",

--- a/src/bitcoin-client.js
+++ b/src/bitcoin-client.js
@@ -82,7 +82,7 @@ async function tryCreateAndBroadcastTx(keyPair, outputs, strategy) {
   const fromAddress = getAddressFromPublicKey(keyPair.publicKey);
   const [utxos, { fastestFee }] = await Promise.all([
     bitcoin.addresses.getAddressTxsUtxo(fromAddress),
-    bitcoin.fees.getFeesRecommended(),
+    bitcoin.fees.getFeesRecommended().catch(() => ({ fastestFee: 1 })),
   ]);
   const feeLevel = Math.ceil(fastestFee * FEE_FACTOR);
   const { selected, change } = selectUtxos(utxos, outputs, feeLevel, strategy);

--- a/src/bitcoin-client.js
+++ b/src/bitcoin-client.js
@@ -82,7 +82,7 @@ async function tryCreateAndBroadcastTx(keyPair, outputs, strategy) {
   const fromAddress = getAddressFromPublicKey(keyPair.publicKey);
   const [utxos, { fastestFee }] = await Promise.all([
     bitcoin.addresses.getAddressTxsUtxo(fromAddress),
-    bitcoin.fees.getFeesRecommended().catch(() => ({ fastestFee: 1 })),
+    bitcoin.fees.getFeesRecommended().catch(() => ({ fastestFee: 250 })),
   ]);
   const feeLevel = Math.ceil(fastestFee * FEE_FACTOR);
   const { selected, change } = selectUtxos(utxos, outputs, feeLevel, strategy);


### PR DESCRIPTION
If the Mempool API is failing to provide fees, let's us a default minimum value of 1 sat/byte.

## Context

The Mempool API is currently returning an error when requesting the fee levels:

```console
curl -sSL "https://mempool.space/testnet/api/v1/fees/recommended" -i
HTTP/2 503 
server: nginx
date: Thu, 19 Sep 2024 14:21:44 GMT
content-type: text/html; charset=utf-8
content-length: 19
x-powered-by: Express
access-control-allow-origin: *
etag: W/"13-/70LdyMNgL+PAJa+Q/RtnRF82z8"

Service Unavailable
```

The other API endpoints are operating so the bot may be able to work if we just default to 1 sat/byte. The tx may take longer to go through but may at least not fail to process the user command as it is happening now.

Note: the testnet3 seem to be under some kind of attack as blocks are mined every few seconds and it looks like the Mempool API is not able to keep in sync.