### PR TITLE
Better error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bitcoin-faucet-bot",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "author": {
     "name": "Gabriel Montes",
@@ -49,6 +49,9 @@
     "entry": [
       "src/bot.js",
       "src/deploy-commands.js"
+    ],
+    "ignore": [
+      "test/**"
     ]
   },
   "lint-staged": {

--- a/src/events.js
+++ b/src/events.js
@@ -40,25 +40,25 @@ const onInteractionCreateEvent = {
       return;
     }
 
-    if (!coolDowns.has(command.data.name)) {
-      coolDowns.set(command.data.name, new Collection());
-    }
-    const timestamps = coolDowns.get(command.data.name);
-    if (
-      timestamps.has(interaction.user.id) &&
-      timestamps.get(interaction.user.id) > Date.now()
-    ) {
-      const waitTime = formatDistanceToNowStrict(
-        new Date(timestamps.get(interaction.user.id)),
-      );
-      await interaction.reply({
-        content: `Please wait ${waitTime} before executing this command again.`,
-        ephemeral: true,
-      });
-      return;
-    }
-
     try {
+      if (!coolDowns.has(command.data.name)) {
+        coolDowns.set(command.data.name, new Collection());
+      }
+      const timestamps = coolDowns.get(command.data.name);
+      if (
+        timestamps.has(interaction.user.id) &&
+        timestamps.get(interaction.user.id) > Date.now()
+      ) {
+        const waitTime = formatDistanceToNowStrict(
+          new Date(timestamps.get(interaction.user.id)),
+        );
+        await interaction.reply({
+          content: `Please wait ${waitTime} before executing this command again.`,
+          ephemeral: true,
+        });
+        return;
+      }
+
       const success = await command.execute(client, interaction);
       if (success) {
         timestamps.set(
@@ -84,4 +84,16 @@ const onInteractionCreateEvent = {
   name: Events.InteractionCreate,
 };
 
-export const eventDefinitions = [onReadyEvent, onInteractionCreateEvent];
+const onErrorEvent = {
+  async execute(client, error) {
+    const logChannel = client.channels.cache.get(config.logChannelId);
+    await logChannel.send(`General failure: ${error.message || error}`);
+  },
+  name: Events.Error,
+};
+
+export const eventDefinitions = [
+  onErrorEvent,
+  onInteractionCreateEvent,
+  onReadyEvent,
+];


### PR DESCRIPTION
This PR extend the main try/catch block to include more calls to the Discord API and adds a dedicated error handler to prevent Node to crash if an `error` event is dispatched without having such a handler.