### PR TITLE
Improve how fee rates are retrieved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bitcoin-faucet-bot",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "license": "MIT",
   "author": {
     "name": "Gabriel Montes",


### PR DESCRIPTION
Mempool.space's unsupported fee estimates endpoint is not returning good fee rates. An improved, and more complex, logic is then required.