### PR TITLE
Use a stricter rate limiting logic

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -59,13 +59,8 @@ const onInteractionCreateEvent = {
         return;
       }
 
-      const success = await command.execute(client, interaction);
-      if (success) {
-        timestamps.set(
-          interaction.user.id,
-          Date.now() + command.coolDown * 1000,
-        );
-      }
+      timestamps.set(interaction.user.id, Date.now() + command.coolDown * 1000);
+      await command.execute(client, interaction);
     } catch (err) {
       const logChannel = client.channels.cache.get(config.logChannelId);
       await logChannel.send(`Command execution failure: ${err.message}`);


### PR DESCRIPTION
Whether the command executes successfully or not, the flag used to check the user's rate is read and written synchronously.

In the previous logic it was able to overcome the limits as many calls may "go through" in between the flag was checked and when it was set after the asynchronous command completed. Even more, if the command was unsuccessful, the flag was not set at all.

That made sense for normal and legitimate usage. But to defend against attacking bots, a stricter logic works better.